### PR TITLE
Manual search: Focus text field when opened

### DIFF
--- a/src/Jackett/Content/custom.js
+++ b/src/Jackett/Content/custom.js
@@ -467,6 +467,10 @@ function bindUIButtons() {
             var releaseDialog = $(releaseTemplate({ indexers: indexers }));
             $("#modals").append(releaseDialog);
             releaseDialog.modal("show");
+            
+            releaseDialog.on('shown.bs.modal', function() {
+                releaseDialog.find('#searchquery').focus();
+            });
 
             var setCategories = function (tracker, items) {
                 var cats = {};


### PR DESCRIPTION
It usually is expected that the main input field in a model is focused.
